### PR TITLE
Enable upgrading with Releases in private repos

### DIFF
--- a/.github/workflows/build-bin.yaml
+++ b/.github/workflows/build-bin.yaml
@@ -1,0 +1,53 @@
+on:
+  pull_request:
+    branches:    
+      - main
+  push:
+    branches:
+      - 'main'
+jobs:
+  bin-build-test-ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.42
+      - name: deno build-linux
+        run: deno task build-linux
+      - name: linux demo hello
+        run: ./dist/linux/in/demo hello
+        timeout-minutes: 1
+      - name: linux demo upgrade
+        run: ./dist/linux/in/demo upgrade --force
+        timeout-minutes: 1
+  bin-build-test-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.42
+      - name: deno build-mac
+        run: deno task build-mac
+      - name: mac demo hello
+        run: ./dist/mac/in/demo hello
+        timeout-minutes: 1
+      - name: mac demo upgrade
+        run: ./dist/mac/in/demo upgrade --force
+        timeout-minutes: 1
+  bin-build-test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.42
+      - name: deno build-win
+        run: deno task build-win
+      - name: win demo upgrade
+        run: ./dist/win/in/demo.exe upgrade --force
+        timeout-minutes: 1

--- a/.github/workflows/build-demo.yaml
+++ b/.github/workflows/build-demo.yaml
@@ -1,0 +1,49 @@
+name: Build and Release for GitHub
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deno
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.42
+
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get version from deno.json
+        uses: polyseam/get-version-key-from-json@v1.0.0
+        id: get_deno_json
+        with:
+          path-to-json: "./deno.json"
+
+      - name: Get the tag version without prefix
+        id: get_version_from_ref
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\/v/}" >> $GITHUB_OUTPUT
+
+      - name: Compare Git Tag to Demo Version
+        if: ${{ steps.get_deno_json.outputs.version != steps.get_version_from_ref.outputs.VERSION }}
+        run: |
+          echo "Demo Version: ${{ steps.get_deno_json.outputs.version }} does not match Tag version: ${{ steps.get_version_from_ref.outputs.VERSION }}" && exit 1
+
+      - name: Test
+        run: deno task test
+
+      - name: Build
+        run: deno task build
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          generate_release_notes: true
+          files: |
+            dist/release-archives/demo-*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 demo-dist/
 !demo-dist/.keep
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-demo-dist/
-!demo-dist/.keep
 .env
+dist
+.DS_Store

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,19 @@
+# @cliffy-provider-gh-releases/demo
+
+A small sandbox to demonstrate the usage of the
+[cliffy-provider-gh-releases](../) module.
+
+## usage
+
+1. Create a repo on GitHub with a Release
+2. update [./demo.ts](./demo.ts) to point to it
+3. If you are using a private repo, set the `GITHUB_TOKEN` environment variable
+   to a
+   [personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)
+   with the `repo` scope
+
+Then you can run the demo application with the following command:
+
+```sh
+deno task run upgrade --version v1.0.0
+```

--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -1,14 +1,13 @@
-import { join } from "@std/path";
+import { join } from "jsr:@std/path@0.222.1";
+import { colors } from "jsr:@cliffy/ansi@1.0.0-rc.4";
+import { Command } from "jsr:@cliffy/command@1.0.0-rc.4";
 import {
   GHRError,
   GithubReleasesProvider,
   GithubReleasesUpgradeCommand,
 } from "../mod.ts";
-import { colors } from "@cliffy/ansi";
-import { Command } from "@cliffy/command";
 
-// Deno.cwd() is the parent directory of the demo directory
-const destinationDir = join(Deno.cwd(), "demo", "demo-dist", "bin");
+const destinationDir = join(Deno.cwd(), "dist");
 
 function printError(error: GHRError) {
   console.log("\n");
@@ -28,6 +27,8 @@ const upgradeCommand = new GithubReleasesUpgradeCommand({
     destinationDir,
     osAssetMap: {
       darwin: "hello-worlds-mac.tar.gz",
+      linux: "hello-worlds-linux.tar.gz",
+      windows: "hello-worlds-windows.zip",
     },
     onError: (error: GHRError) => {
       printError(error);

--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -12,6 +12,7 @@ const destinationDir = join(Deno.cwd(), "dist");
 function printError(error: GHRError) {
   console.log("\n");
   console.error("error:", colors.brightRed(error.message));
+  console.error("code:", colors.brightRed(`${error.code}`));
 
   if (error.metadata) {
     for (const key in error.metadata) {
@@ -23,12 +24,12 @@ function printError(error: GHRError) {
 
 const upgradeCommand = new GithubReleasesUpgradeCommand({
   provider: new GithubReleasesProvider({
-    repository: "polyseam/private-release",
+    repository: "polyseam/cliffy-provider-github-releases",
     destinationDir,
     osAssetMap: {
-      darwin: "hello-worlds-mac.tar.gz",
-      linux: "hello-worlds-linux.tar.gz",
-      windows: "hello-worlds-windows.zip",
+      darwin: "demo-mac.tar.gz",
+      linux: "demo-linux.tar.gz",
+      windows: "demo-windows.tar.gz",
     },
     onError: (error: GHRError) => {
       printError(error);

--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -3,7 +3,7 @@ import {
   GHRError,
   GithubReleasesProvider,
   GithubReleasesUpgradeCommand,
-} from "@polyseam/cliffy-provider-gh-releases";
+} from "../mod.ts";
 import { colors } from "@cliffy/ansi";
 import { Command } from "@cliffy/command";
 
@@ -24,12 +24,10 @@ function printError(error: GHRError) {
 
 const upgradeCommand = new GithubReleasesUpgradeCommand({
   provider: new GithubReleasesProvider({
-    repository: "polyseam/cndi",
+    repository: "polyseam/private-release",
     destinationDir,
     osAssetMap: {
-      windows: "cndi-win.tar.gz",
-      linux: "cndi-linux.tar.gz",
-      darwin: "cndi-mac.tar.gz",
+      darwin: "hello-worlds-mac.tar.gz",
     },
     onError: (error: GHRError) => {
       printError(error);
@@ -48,7 +46,7 @@ const cli = new Command()
   .version("0.1.0")
   .command(
     "hello",
-    new Command().action(() => console.log("Hello World!"))
+    new Command().action(() => console.log("Hello World!")),
   )
   .command("upgrade", upgradeCommand);
 

--- a/demo/deno.json
+++ b/demo/deno.json
@@ -1,5 +1,5 @@
 {
-  "name": "gh-upgrade-demo",
+  "name": "@cliffy-provider-gh-releases/demo",
   "tasks": {
     "dev": "deno run --watch main.ts",
     "run": "export $(xargs < .env) && deno run -A demo.ts"

--- a/demo/deno.json
+++ b/demo/deno.json
@@ -2,7 +2,20 @@
   "name": "@cliffy-provider-gh-releases/demo",
   "tasks": {
     "dev": "deno run --watch main.ts",
-    "run": "export $(xargs < .env) && deno run -A demo.ts"
+    "run": "export $(xargs < .env) && deno run -A demo.ts",
+    "tar-win": "tar -czvf dist/release-archives/demo-win.tar.gz -C dist/win/in .",
+    "tar-linux": "tar -czvf dist/release-archives/demo-linux.tar.gz -C dist/linux/in .",
+    "tar-mac": "tar -czvf dist/release-archives/demo-mac.tar.gz -C dist/mac/in .",
+    "tar-all": "deno task tar-mac && deno task tar-win && deno task tar-linux",
+    "clean-dist": "rm -rf dist && mkdir -p dist/win/in && mkdir -p dist/linux/in && mkdir -p dist/mac/in && mkdir -p dist/release-archives",
+    "compile-win": "deno compile --allow-all --target x86_64-pc-windows-msvc --output dist/win/in/demo.exe demo.ts",
+    "compile-linux": "deno compile --allow-all --target x86_64-unknown-linux-gnu --output dist/linux/in/demo demo.ts",
+    "compile-mac": "deno compile --allow-all --target x86_64-apple-darwin --output dist/mac/in/demo demo.ts",
+    "compile-all": "deno task compile-win && deno task compile-linux && deno task compile-mac",
+    "build": "deno lint && deno fmt && deno task clean-dist && deno task compile-all && deno task tar-all",
+    "build-mac": "deno lint && deno fmt && deno task clean-dist && deno task compile-mac",
+    "build-linux": "deno lint && deno fmt && deno task clean-dist && deno task compile-linux",
+    "build-win": "deno lint && deno fmt && deno task clean-dist && deno task compile-win"
   },
   "exports": "./demo.ts",
   "importMap": "../import_map.json"

--- a/demo/deno.json
+++ b/demo/deno.json
@@ -1,13 +1,9 @@
 {
   "name": "gh-upgrade-demo",
   "tasks": {
-    "dev": "deno run --watch main.ts"
+    "dev": "deno run --watch main.ts",
+    "run": "export $(xargs < .env) && deno run -A demo.ts"
   },
   "exports": "./demo.ts",
-  "imports": {
-    "@cliffy/ansi": "jsr:@cliffy/ansi@^1.0.0-rc.4",
-    "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.4",
-    "@std/path": "jsr:@std/path@^0.221.0",
-    "@polyseam/cliffy-provider-gh-releases": "jsr:@polyseam/cliffy-provider-gh-releases@^0.1.1"
-  }
+  "importMap": "../import_map.json"
 }

--- a/demo/deno.lock
+++ b/demo/deno.lock
@@ -2,7 +2,9 @@
   "version": "3",
   "packages": {
     "specifiers": {
+      "jsr:@cliffy/ansi@1.0.0-rc.4": "jsr:@cliffy/ansi@1.0.0-rc.4",
       "jsr:@cliffy/ansi@^1.0.0-rc.4": "jsr:@cliffy/ansi@1.0.0-rc.4",
+      "jsr:@cliffy/command@1.0.0-rc.4": "jsr:@cliffy/command@1.0.0-rc.4",
       "jsr:@cliffy/command@^1.0.0-rc.4": "jsr:@cliffy/command@1.0.0-rc.4",
       "jsr:@cliffy/flags@1.0.0-rc.4": "jsr:@cliffy/flags@1.0.0-rc.4",
       "jsr:@cliffy/table@1.0.0-rc.4": "jsr:@cliffy/table@1.0.0-rc.4",
@@ -10,6 +12,7 @@
       "jsr:@std/archive@0.214.0": "jsr:@std/archive@0.214.0",
       "jsr:@std/assert@^0.214.0": "jsr:@std/assert@0.214.0",
       "jsr:@std/assert@^0.221.0": "jsr:@std/assert@0.221.0",
+      "jsr:@std/assert@^0.222.1": "jsr:@std/assert@0.222.1",
       "jsr:@std/bytes@^0.214.0": "jsr:@std/bytes@0.214.0",
       "jsr:@std/cli@^0.221.0": "jsr:@std/cli@0.221.0",
       "jsr:@std/console@0.221": "jsr:@std/console@0.221.0",
@@ -21,6 +24,7 @@
       "jsr:@std/io@0.221": "jsr:@std/io@0.221.0",
       "jsr:@std/io@^0.214.0": "jsr:@std/io@0.214.0",
       "jsr:@std/path@0.214.0": "jsr:@std/path@0.214.0",
+      "jsr:@std/path@0.222.1": "jsr:@std/path@0.222.1",
       "jsr:@std/path@^0.214.0": "jsr:@std/path@0.214.0",
       "jsr:@std/path@^0.221.0": "jsr:@std/path@0.221.0",
       "jsr:@std/semver@^0.221.0": "jsr:@std/semver@0.221.0",
@@ -75,6 +79,9 @@
       "@std/assert@0.221.0": {
         "integrity": "a5f1aa6e7909dbea271754fd4ab3f4e687aeff4873b4cef9a320af813adb489a"
       },
+      "@std/assert@0.222.1": {
+        "integrity": "691637161ee584a9919d1f9950ddd1272feb8e0a19e83aa5b7563cedaf73d74c"
+      },
       "@std/bytes@0.214.0": {
         "integrity": "eba2a06824fd22b9cb1214c53988ad57431177497e6198ba0ff8ab207dae996f"
       },
@@ -125,6 +132,12 @@
         "integrity": "0a36f6b17314ef653a3a1649740cc8db51b25a133ecfe838f20b79a56ebe0095",
         "dependencies": [
           "jsr:@std/assert@^0.221.0"
+        ]
+      },
+      "@std/path@0.222.1": {
+        "integrity": "aad3e9463ca53b0adb25b4d5beb330025674aaa3278da24c1c261d9289a9e48b",
+        "dependencies": [
+          "jsr:@std/assert@^0.222.1"
         ]
       },
       "@std/semver@0.221.0": {

--- a/demo/deno.lock
+++ b/demo/deno.lock
@@ -6,7 +6,6 @@
       "jsr:@cliffy/command@^1.0.0-rc.4": "jsr:@cliffy/command@1.0.0-rc.4",
       "jsr:@cliffy/flags@1.0.0-rc.4": "jsr:@cliffy/flags@1.0.0-rc.4",
       "jsr:@cliffy/table@1.0.0-rc.4": "jsr:@cliffy/table@1.0.0-rc.4",
-      "jsr:@polyseam/cliffy-provider-gh-releases@^0.1.1": "jsr:@polyseam/cliffy-provider-gh-releases@0.1.1",
       "jsr:@polyseam/inflate-response@^1.1.2": "jsr:@polyseam/inflate-response@1.1.2",
       "jsr:@std/archive@0.214.0": "jsr:@std/archive@0.214.0",
       "jsr:@std/assert@^0.214.0": "jsr:@std/assert@0.214.0",
@@ -55,17 +54,6 @@
           "jsr:@std/console@0.221"
         ]
       },
-      "@polyseam/cliffy-provider-gh-releases@0.1.1": {
-        "integrity": "3a02a6c683cc92ee1f8423edc2d2486c0a20df3076c6cdb65a30be66a02dc55d",
-        "dependencies": [
-          "jsr:@cliffy/command@^1.0.0-rc.4",
-          "jsr:@polyseam/inflate-response@^1.1.2",
-          "jsr:@std/cli@^0.221.0",
-          "jsr:@std/fs@^0.221.0",
-          "jsr:@std/semver@^0.221.0",
-          "npm:octokit@^3.1.2"
-        ]
-      },
       "@polyseam/inflate-response@1.1.2": {
         "integrity": "ef7e85c4528b36b7649cfa4f4ca44215eec4c690b6d5c376cfa2e037d4af4385",
         "dependencies": [
@@ -91,7 +79,10 @@
         "integrity": "eba2a06824fd22b9cb1214c53988ad57431177497e6198ba0ff8ab207dae996f"
       },
       "@std/cli@0.221.0": {
-        "integrity": "157c2f881f0f85a73d994e7668754aeeccdf597680bd9c65de9c6bcd670416ac"
+        "integrity": "157c2f881f0f85a73d994e7668754aeeccdf597680bd9c65de9c6bcd670416ac",
+        "dependencies": [
+          "jsr:@std/assert@^0.221.0"
+        ]
       },
       "@std/console@0.221.0": {
         "integrity": "8f2afc1f3f14f5d6039c0c767f057e4aa1897d2210e167c4667cb155cafb9d11"
@@ -111,6 +102,7 @@
       "@std/fs@0.221.0": {
         "integrity": "028044450299de8ed5a716ade4e6d524399f035513b85913794f4e81f07da286",
         "dependencies": [
+          "jsr:@std/assert@^0.221.0",
           "jsr:@std/path@^0.221.0"
         ]
       },
@@ -530,13 +522,5 @@
       }
     }
   },
-  "remote": {},
-  "workspace": {
-    "dependencies": [
-      "jsr:@cliffy/ansi@^1.0.0-rc.4",
-      "jsr:@cliffy/command@^1.0.0-rc.4",
-      "jsr:@polyseam/cliffy-provider-gh-releases@^0.1.1",
-      "jsr:@std/path@^0.221.0"
-    ]
-  }
+  "remote": {}
 }

--- a/deno.json
+++ b/deno.json
@@ -1,14 +1,13 @@
 {
   "name": "@polyseam/cliffy-provider-gh-releases",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "tasks": {
     "demo": "deno run -A ./demo/demo.ts"
   },
   "exports": "./mod.ts",
   "exclude": [
     "demo",
-    "test",
-    "demo-distance"
+    "test"
   ],
   "imports": {
     "@cliffy/ansi": "jsr:@cliffy/ansi@^1.0.0-rc.4",

--- a/deno.json
+++ b/deno.json
@@ -13,6 +13,7 @@
   "imports": {
     "@cliffy/ansi": "jsr:@cliffy/ansi@^1.0.0-rc.4",
     "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.4",
+    "@octokit/types": "npm:@octokit/types@^13.4.1",
     "@polyseam/inflate-response": "jsr:@polyseam/inflate-response@^1.1.2",
     "@std/cli": "jsr:@std/cli@^0.221.0",
     "@std/fs": "jsr:@std/fs@^0.221.0",

--- a/deno.lock
+++ b/deno.lock
@@ -25,6 +25,7 @@
       "jsr:@std/path@^0.221.0": "jsr:@std/path@0.221.0",
       "jsr:@std/semver@^0.221.0": "jsr:@std/semver@0.221.0",
       "jsr:@std/text@0.221": "jsr:@std/text@0.221.0",
+      "npm:@octokit/types@^13.4.1": "npm:@octokit/types@13.4.1",
       "npm:@types/node": "npm:@types/node@18.16.19",
       "npm:octokit@^3.1.2": "npm:octokit@3.1.2_@octokit+core@5.1.0",
       "npm:semver": "npm:semver@7.5.4",
@@ -259,6 +260,10 @@
         "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
         "dependencies": {}
       },
+      "@octokit/openapi-types@22.1.0": {
+        "integrity": "sha512-pGUdSP+eEPfZiQHNkZI0U01HLipxncisdJQB4G//OAmfeO8sqTQ9KRa0KF03TUPCziNsoXUrTg4B2Q1EX++T0Q==",
+        "dependencies": {}
+      },
       "@octokit/plugin-paginate-graphql@4.0.1_@octokit+core@5.1.0": {
         "integrity": "sha512-R8ZQNmrIKKpHWC6V2gum4x9LG2qF1RxRjo27gjQcG3j+vf2tLsEfE7I/wRWEPzYMaenr1M+qDAtNcwZve1ce1A==",
         "dependencies": {
@@ -317,6 +322,12 @@
         "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
         "dependencies": {
           "@octokit/openapi-types": "@octokit/openapi-types@20.0.0"
+        }
+      },
+      "@octokit/types@13.4.1": {
+        "integrity": "sha512-Y73oOAzRBAUzR/iRAbGULzpNkX8vaxKCqEtg6K74Ff3w9f5apFnWtE/2nade7dMWWW3bS5Kkd6DJS4HF04xreg==",
+        "dependencies": {
+          "@octokit/openapi-types": "@octokit/openapi-types@22.1.0"
         }
       },
       "@octokit/webhooks-methods@4.1.0": {
@@ -818,6 +829,7 @@
       "jsr:@std/cli@^0.221.0",
       "jsr:@std/fs@^0.221.0",
       "jsr:@std/semver@^0.221.0",
+      "npm:@octokit/types@^13.4.1",
       "npm:octokit@^3.1.2"
     ]
   }

--- a/deps.ts
+++ b/deps.ts
@@ -5,9 +5,11 @@ export type {
   GithubVersions,
   UpgradeOptions,
 } from "@cliffy/command/upgrade";
-
 export { colors } from "@cliffy/ansi";
+
+// node builtins
 export { homedir } from "node:os";
+
 // std
 export { Spinner } from "@std/cli/spinner";
 export { type SpinnerOptions } from "@std/cli/spinner";
@@ -21,6 +23,7 @@ export { ensureDirSync, walkSync } from "@std/fs";
 
 // github
 export { Octokit } from "octokit";
+export type { Endpoints as OctokitEndpoints } from "@octokit/types";
 
 // homegrown
 export { inflateResponse } from "@polyseam/inflate-response";

--- a/import_map.json
+++ b/import_map.json
@@ -10,6 +10,7 @@
     "@std/semver": "jsr:@std/semver@^0.221.0",
     "@std/semver/compare": "jsr:@std/semver@^0.221.0",
     "@std/path": "jsr:@std/path@^0.221.0",
-    "octokit": "npm:octokit@^3.1.2"
+    "octokit": "npm:octokit@^3.1.2",
+    "@octokit/types": "npm:@octokit/types@^13.4.1"
   }
 }

--- a/import_map.json
+++ b/import_map.json
@@ -1,0 +1,15 @@
+{
+  "imports": {
+    "@cliffy/ansi": "jsr:@cliffy/ansi@^1.0.0-rc.4",
+    "@cliffy/command": "jsr:@cliffy/command@^1.0.0-rc.4",
+    "@cliffy/command/upgrade": "jsr:@cliffy/command@^1.0.0-rc.4",
+    "@polyseam/inflate-response": "jsr:@polyseam/inflate-response@^1.1.2",
+    "@std/cli": "jsr:@std/cli@^0.221.0",
+    "@std/cli/spinner": "jsr:@std/cli@^0.221.0",
+    "@std/fs": "jsr:@std/fs@^0.221.0",
+    "@std/semver": "jsr:@std/semver@^0.221.0",
+    "@std/semver/compare": "jsr:@std/semver@^0.221.0",
+    "@std/path": "jsr:@std/path@^0.221.0",
+    "octokit": "npm:octokit@^3.1.2"
+  }
+}

--- a/mod.ts
+++ b/mod.ts
@@ -30,24 +30,29 @@ type ReleaseParameters =
 type AssetParameters =
   OctokitEndpoints["GET /repos/{owner}/{repo}/releases/assets/{asset_id}"]["parameters"];
 
-
 /**
  * ERROR_CODE_MAP
  * A map of error codes to human-readable error messages
  ***/
 export const ERROR_CODE_MAP = {
-  1: "repository must be in the format 'owner/repo'",
-  2: "Found old version but failed to delete",
-  3: "No asset found for the current OS",
-  4: "Network Error: Failed to fetch GitHub Release Asset",
-  5: "Network Error: Failed to fetch GitHub Release List",
-  6: "Failed to inflate response",
-  7: "Failed to stash old version",
-  8: "Failed to install new version",
-  1404: "GitHub Release Asset Not Found",
-  1403: "GitHub Release Asset Request Forbidden",
-  2404: "GitHub Release List Not Found",
-  2403: "GitHub Release List Request Forbidden",
+  1: "repository must be in the format 'owner/repo'", // Provider options configured incorrectly
+  2: "Found old version but failed to delete", // old version found but failed to delete
+  3: "No asset name found for the current OS", // asset name not found in osAssetMap
+  4: "No asset found for the current OS", // asset not found in release
+  5: "Network Error: failed to fetch GitHub Release Asset Data", // fetch() failed
+  // 5xxx errors are for fetch() errors
+  5404: "Failed to fetch GitHub Release Asset Data - Not Found",
+  5500: "Failed to fetch GitHub Release Asset - Internal Server Error",
+  // 6xxx errors are for octokit.request(data) errors
+  6404: "Failed to octokit.request GitHub Release Asset Data - Not Found",
+  6500: "Failed to octokit.request GitHub Release Asset Data - Internal Server Error",
+  // 7xxx errors are for octokit.request(release list) errors
+  7404: "Failed to octokit.request Release List from GitHub - Not Found",
+  7500: "Failed to octokit.request Release List from GitHub - Internal Server Error",
+  8: "Failed to extract archive", // inflateResponse failed
+  9: "Failed to stash old version", // rename running bin failed
+  10: "Failed to install new version", // write new bin failed
+
 };
 
 /**
@@ -238,11 +243,19 @@ export class GithubReleasesProvider extends Provider {
     opt: AssetParameters;
   } {
     const assetName = this.osAssetMap[Deno.build.os];
+
+    if (!assetName) {
+      throw new GHRError("Failed to find asset name for current OS", 3, {
+        os: Deno.build.os,
+        osAssetMap: this.osAssetMap,
+      });
+    }
+
     const asset = releaseResponse.data.assets.find(
       (asset: { name: string }) => asset.name === assetName
     );
     if (!asset) {
-      throw new GHRError("Failed to find asset for current OS", 3, {
+      throw new GHRError("Failed to find asset for current OS", 4, {
         os: Deno.build.os,
         assetName,
         assets: releaseResponse.data.assets,
@@ -296,30 +309,58 @@ export class GithubReleasesProvider extends Provider {
     let errorDetail = {};
 
     if (this.skipAuth) {
-      const assetName = this.osAssetMap[os];
-      if (!assetName) {
-        const error = new GHRError("Failed to find asset for current OS", 3, {
-          os,
-          osAssetMap: this.osAssetMap,
-        });
+      try {
+        const assetName = this.osAssetMap[os];
+        if (!assetName) {
+          const error = new GHRError("Failed to find asset name for current OS", 3, {
+            os,
+            osAssetMap: this.osAssetMap,
+          });
+          this.onError?.(error);
+          throw error;
+        }
+        const url = `https://github.com/${this.owner}/${this.repo}/releases/download/${to}/${assetName}`;
+        response = await fetch(url);
+        errorDetail = {
+          url,
+        };
+        if(response.status !== 200){
+          throw new GHRError(
+            "Failed to fetch GitHub Release Asset",
+            parseInt(`5${response.status}`),
+            {
+              ...errorDetail,
+              status: response.status,
+            }
+          );
+        }
+      } catch (caught) {
+        const error = new GHRError(
+          "Network Error: Failed to fetch GitHub Release Asset",
+          5,
+          {
+            ...errorDetail,
+            caught,
+          }
+        );
         this.onError?.(error);
         throw error;
       }
-      const url = `https://github.com/${this.owner}/${this.repo}/releases/download/${to}/${assetName}`;
-      response = await fetch(url);
-      errorDetail = {
-        url,
-      };
     } else {
       const req = this.getReleaseOctokitRequest(to);
 
-      const releaseResponse = await this.octokit.request(req.path, req.opt);
-
-      if (releaseResponse.status !== 200) {
-        const error = new GHRError("Failed to fetch release metadata", 4, {
-          status: releaseResponse.status,
-          url: releaseResponse.url,
-        });
+      let releaseResponse; // Release Metadata
+      try {
+        releaseResponse = await this.octokit.request(req.path, req.opt);
+      } catch (errorFetching) {
+        const error = new GHRError(
+          "Failed to fetch Release metadata",
+          parseInt(`5${errorFetching.status}`),
+          {
+            ...req,
+            caught: errorFetching,
+          }
+        );
         this.onError?.(error);
         throw error;
       }
@@ -347,28 +388,14 @@ export class GithubReleasesProvider extends Provider {
           },
         });
 
-        if (octokitAssetResponse.status !== 200) {
-          const error = new GHRError(
-            "Failed to fetch GitHub Release Asset Data",
-            4,
-            {
-              assetReqPath,
-              assetReqOpt,
-              status: octokitAssetResponse.status,
-            }
-          );
-          this.onError?.(error);
-          throw error;
-        }
-
         // how costly is creating a Response?
         response = new Response(octokitAssetResponse.data, {
           status: octokitAssetResponse.status,
         });
       } catch (errorFetching) {
         const error = new GHRError(
-          "Network Error: Failed to fetch GitHub Release Asset",
-          4,
+          "Failed to fetch GitHub Release Asset Data",
+          parseInt(`6${errorFetching.status}`),
           {
             ...errorDetail,
             caught: errorFetching,
@@ -379,105 +406,70 @@ export class GithubReleasesProvider extends Provider {
       }
     }
 
-    if (response.body && response.status === 200) {
-      try {
-        await inflateResponse(response, stagingDir, {
-          compressionFormat: "gzip",
-          doUntar: true,
-        });
-      } catch (caught) {
-        const error = new GHRError("Failed to inflate response", 6, {
-          caught,
-        });
-        this.onError?.(error);
-        throw error;
-      }
+    try {
+      await inflateResponse(response, stagingDir, {
+        compressionFormat: "gzip",
+        doUntar: true,
+      });
+    } catch (caught) {
+      const error = new GHRError(`Failed to extract '${this.osAssetMap[os]}' archive`, 8, {
+        caught,
+      });
+      this.onError?.(error);
+      throw error;
+    }
 
-      for (const entry of walkSync(stagingDir)) {
-        if (entry.isFile) {
-          const finalPath = entry.path.replace(stagingDir, this.destinationDir);
+    for (const entry of walkSync(stagingDir)) {
+      if (entry.isFile) {
+        const finalPath = entry.path.replace(stagingDir, this.destinationDir);
 
-          try {
-            // stash the old version
-            Deno.renameSync(finalPath, `${finalPath}${OLD_VERSION_TAG}`);
-          } catch (caught) {
-            if (!(caught instanceof Deno.errors.NotFound)) {
-              const error = new GHRError("Failed to stash old version", 7, {
-                caught,
-                oldfile: finalPath,
-              });
-              this.onError?.(error);
-              throw error;
-            }
-          }
-
-          // install the new version
-          try {
-            Deno.renameSync(entry.path, finalPath);
-          } catch (caught) {
-            const error = new GHRError("Failed to install new version", 8, {
+        try {
+          // stash the old version
+          Deno.renameSync(finalPath, `${finalPath}${OLD_VERSION_TAG}`);
+        } catch (caught) {
+          if (!(caught instanceof Deno.errors.NotFound)) {
+            const error = new GHRError("Failed to stash old version", 9, {
               caught,
-              newfile: entry.path,
+              oldfile: finalPath,
             });
             this.onError?.(error);
             throw error;
           }
-          if (os !== "windows") {
-            Deno.chmodSync(finalPath, 0o755);
-          }
+        }
+
+        // install the new version
+        try {
+          Deno.renameSync(entry.path, finalPath);
+        } catch (caught) {
+          const error = new GHRError("Failed to install new version", 10, {
+            caught,
+            newfile: entry.path,
+          });
+          this.onError?.(error);
+          throw error;
+        }
+        if (os !== "windows") {
+          Deno.chmodSync(finalPath, 0o755);
         }
       }
-
-      this?.onComplete?.({ to, from }, function printSuccessMessage() {
-        spinner.stop();
-        const fromMsg = from ? ` from version ${colors.yellow(from)}` : "";
-        console.log(
-          `Successfully upgraded ${colors.cyan(
-            name
-          )}${fromMsg} to version ${colors.green(to)}!\n`
-        );
-      });
-    } else {
-      if (response.status === 404) {
-        const error = new GHRError("GitHub Release Asset Not Found", 1404, {
-          ...errorDetail,
-          status: response.status,
-        });
-        this.onError?.(error);
-        throw error;
-      }
-
-      if (response.status === 403) {
-        const error = new GHRError(
-          "GitHub Release Asset Request Forbidden",
-          1403,
-          {
-            ...errorDetail,
-            status: response.status,
-          }
-        );
-        this.onError?.(error);
-        throw error;
-      }
-
-      const error = new GHRError(
-        "GitHub Release Asset Request Failed",
-        parseInt(`1${response.status}`),
-        {
-          ...errorDetail,
-          status: response.status,
-        }
-      );
-
-      this.onError?.(error);
-      throw error;
     }
+
+    this?.onComplete?.({ to, from }, function printSuccessMessage() {
+      spinner.stop();
+      const fromMsg = from ? ` from version ${colors.yellow(from)}` : "";
+      console.log(
+        `Successfully upgraded ${colors.cyan(
+          name
+        )}${fromMsg} to version ${colors.green(to)}!\n`
+      );
+    });
   }
 
   async getVersions(_name: string): Promise<GithubReleaseVersions> {
     const url = `https://api.github.com/repos/${this.owner}/${this.repo}/releases`;
+    let listReleasesResponse;
     try {
-      const listReleasesResponse = await this.octokit.request(
+      listReleasesResponse = await this.octokit.request(
         "GET /repos/{owner}/{repo}/releases",
         {
           owner: this.owner,
@@ -487,75 +479,42 @@ export class GithubReleasesProvider extends Provider {
           },
         }
       );
-
-      if (listReleasesResponse.status === 200) {
-        const versions = listReleasesResponse.data
-          .filter((release) => {
-            // never include draft releases
-            if (release.draft) return false;
-            // only include prereleases if the prerelease option is set to true
-            if (release.prerelease) {
-              if (this.prerelease) return true;
-              // otherwise include all non-prerelease releases
-              return false;
-            }
-            return true;
-          })
-          .map(({ tag_name }) => tag_name)
-          .sort(latestSemVerFirst);
-
-        const latest = versions[0];
-
-        return {
-          versions, // branches and tags
-          latest,
-        };
-      } else {
-        if (listReleasesResponse.status === 404) {
-          const error = new GHRError("GitHub Release List Not Found", 2404, {
-            url,
-            status: listReleasesResponse.status,
-          });
-          this.onError?.(error);
-          throw error;
-        }
-
-        if (listReleasesResponse.status === 403) {
-          const error = new GHRError(
-            "GitHub Release List Request Forbidden",
-            2403,
-            {
-              url,
-              status: listReleasesResponse.status,
-            }
-          );
-          this.onError?.(error);
-          throw error;
-        }
-
-        const error = new GHRError(
-          "GitHub Release List Request Failed",
-          parseInt(`2${listReleasesResponse.status}`),
-          {
-            status: listReleasesResponse.status,
-            url,
-          }
-        );
-        this.onError?.(error);
-        throw error;
-      }
     } catch (error) {
-      const getVersionsNetworkError = new GHRError(
-        "Network Error: Failed to fetch Release List from GitHub.",
-        5,
+      const status = error.status;
+
+      const getVersionsError = new GHRError("Failed to octokit.request Release List from GitHub.",
+        parseInt(`7${status}`),
         {
+          status,
           caught: error,
           url,
         }
       );
-      this.onError?.(getVersionsNetworkError);
-      throw getVersionsNetworkError;
+      this.onError?.(getVersionsError);
+      throw getVersionsError;
     }
+
+    const versions = listReleasesResponse.data
+      .filter((release) => {
+        // never include draft releases
+        if (release.draft) return false;
+        // only include prereleases if the prerelease option is set to true
+        if (release.prerelease) {
+          if (this.prerelease) return true;
+          // otherwise include all non-prerelease releases
+          return false;
+        }
+        return true;
+      })
+      .map(({ tag_name }) => tag_name)
+      .sort(latestSemVerFirst);
+
+    const latest = versions[0];
+
+    return {
+      versions, // branches and tags
+      latest,
+    };
   }
 
   async listVersions(


### PR DESCRIPTION
The library has been upgraded to include basic support for Releases in private GitHub Repos. To utilize the functionality just set the `GITHUB_TOKEN` environment variable.

Incidentally, all calls to GitHub now run through octokit. Could this result in rate-limiting issues?